### PR TITLE
Add `--debug` flag which prints logs from pod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,14 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
+    "binary-split": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/binary-split/-/binary-split-1.0.3.tgz",
+      "integrity": "sha1-yqiKyNhZ0zFw9fHOa0xZCHn3UCY=",
+      "requires": {
+        "through2": "^2.0.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -434,8 +442,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -1309,8 +1316,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "6.0.0",
@@ -1405,8 +1411,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1627,6 +1632,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multi-read-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multi-read-stream/-/multi-read-stream-2.0.0.tgz",
+      "integrity": "sha1-2e6GFHQwiUEaTZrH0h04qmjDbkA=",
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4551,8 +4564,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.0",
@@ -4590,7 +4602,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4834,7 +4845,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -4908,6 +4918,15 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -4955,8 +4974,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.2.1",
@@ -5071,6 +5089,11 @@
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
       }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "bignumber.js": "^7.2.1",
+    "binary-split": "^1.0.3",
     "chalk": "^2.4.1",
     "codius-manifest": "^2.0.3",
     "fs-extra": "^6.0.1",
@@ -49,6 +50,7 @@
     "jsome": "^2.5.0",
     "lodash.samplesize": "^4.2.0",
     "moment": "^2.22.2",
+    "multi-read-stream": "^2.0.0",
     "node-dir": "^0.1.17",
     "ora": "^2.1.0",
     "riverpig": "^1.1.4",

--- a/src/cmds/options/options.js
+++ b/src/cmds/options/options.js
@@ -51,6 +51,14 @@ const hostCount = {
   }
 }
 
+const debug = {
+  'debug': {
+    type: 'boolean',
+    default: false,
+    description: 'Run this pod in debug mode with logging'
+  }
+}
+
 const addHostEnv = {
   'add-host-env': {
     alias: 'a',
@@ -144,7 +152,8 @@ const uploadOptions = {
   ...codiusHostsFile,
   ...codiusStateFileUpload,
   ...overwriteCodiusStateFile,
-  ...assumeYes
+  ...assumeYes,
+  ...debug
 }
 
 const extendManifestOptions = {

--- a/src/common/pod-control.js
+++ b/src/common/pod-control.js
@@ -1,0 +1,58 @@
+const logger = require('riverpig')('codius-cli:pod-control')
+const multi = require('multi-read-stream')
+const chalk = require('chalk')
+const split = require('binary-split')
+const { parse: parseUrl } = require('url')
+const { Transform } = require('stream')
+
+async function attachToLogs (hosts, podId) {
+  logger.debug('attaching to logs. hosts=%s podId=%s', hosts, podId)
+
+  const streams = await Promise.all(hosts.map(async host => {
+    const url = parseUrl(host)
+
+    const get = (url.protocol === 'https:' ? require('https') : require('http')).get
+    const res = await new Promise((resolve, reject) => {
+      const req = get(`${host}/pods/${podId}/logs`, resolve)
+
+      req.on('error', err => reject(err))
+    })
+
+    const transform = new Transform({
+      transform (chunk, encoding, callback) {
+        const line = chunk.toString('utf8')
+
+        if (line === 'ping') {
+          return
+        }
+
+        const firstSpaceIndex = line.indexOf(' ')
+        const secondSpaceIndex = line.indexOf(' ', firstSpaceIndex + 1)
+
+        const containerId = line.substring(0, firstSpaceIndex)
+        const streamId = line.substring(firstSpaceIndex + 1, secondSpaceIndex)
+        const logText = line.substring(secondSpaceIndex + 1)
+
+        const streamColor = streamId === 'stdout'
+          ? chalk.green
+          : streamId === 'stderr'
+            ? chalk.red
+            : chalk.blue
+
+        const outputLine = `${chalk.gray(url.hostname)} ${streamColor(containerId)} ${logText}\n`
+
+        callback(null, outputLine)
+      }
+    })
+
+    res.pipe(split()).pipe(transform)
+
+    return transform
+  }))
+
+  return multi(streams)
+}
+
+module.exports = {
+  attachToLogs
+}


### PR DESCRIPTION
Builds on #47. Requires codius/codiusd#85.

Adds a flag to the Codius upload command called `--debug` which causes the CLI to attach to the pod's stdout/stderr. For each log line received it will print the hostname, container name and log message. For stdout, the container name is is in green, for stderr, the container name is in red.

![screenshot-2018-07-03t12 06 23 911z](https://user-images.githubusercontent.com/53233/42218897-e3b7d93a-7e7e-11e8-817c-c68fd6b311b7.png)
