### PR TITLE
feat: Add tail logs support

### DIFF
--- a/bin/codius.js
+++ b/bin/codius.js
@@ -14,4 +14,5 @@ yargs.commandDir('../src/cmds')
   .implies('units', 'max-monthly-rate')
   .implies('codius-file', 'codius-vars-file')
   .implies('codius-vars-file', 'codius-file')
+  .implies('tail', 'debug')
   .argv

--- a/src/cmds/options/options.js
+++ b/src/cmds/options/options.js
@@ -55,7 +55,15 @@ const debug = {
   'debug': {
     type: 'boolean',
     default: false,
-    description: 'Run this pod in debug mode with logging'
+    description: 'Run this pod in debug mode with logging.'
+  }
+}
+
+const tail = {
+  'tail': {
+    type: 'boolean',
+    default: false,
+    description: 'Tail the pods logs on upload. Requires debug mode to be enabled by the --debug flag.'
   }
 }
 
@@ -204,7 +212,8 @@ const uploadOptions = {
   ...codiusStateFileUpload,
   ...overwriteCodiusStateFile,
   ...assumeYes,
-  ...debug
+  ...debug,
+  ...tail
 }
 
 const extendManifestOptions = {
@@ -215,11 +224,17 @@ const extendManifestOptions = {
   ...assumeYes
 }
 
+const tailOptions = {
+  ...setHost,
+  ...codiusStateFileExtend
+}
+
 module.exports = {
   uploadOptions,
   extendOptions,
   extendManifestOptions,
   cronExtendOptions,
   cronViewOptions,
-  cronRemoveOptions
+  cronRemoveOptions,
+  tailOptions
 }

--- a/src/cmds/tail.js
+++ b/src/cmds/tail.js
@@ -1,0 +1,17 @@
+/**
+ * @fileOverview
+ * @name tail.js
+ * @author Travis Crist
+ */
+
+const logger = require('riverpig')('codius-cli:tail')
+const { tailOptions } = require('../cmds/options/options.js')
+const { tail } = require('../handlers/tail.js')
+
+exports.command = 'tail [manifest-hash] [options]'
+exports.desc = 'Tails the pods logs based on the *.codiusstate.json file located in the current directory. Upload must first be used to generate the *.codiusstate.json file with the --debug flag used. Also tails the host specified by the manifest hash and the host name.'
+exports.builder = tailOptions
+exports.handler = async function (argv) {
+  logger.debug(`Tail args: ${JSON.stringify(argv)}`)
+  await tail(argv)
+}

--- a/src/common/codius-state.js
+++ b/src/common/codius-state.js
@@ -201,7 +201,7 @@ async function getCodiusStateFilePath () {
 
 async function getCodiusState (status, options) {
   let codiusStateFilePath
-  if (options.codiusStateFile) {
+  if (options.codiusStateFile !== 'default.codiusstate.json') {
     status.start(`Checking ${options.codiusStateFile} exists`)
     const codiusStateExists = await fse.pathExists(options.codiusStateFile)
     if (!codiusStateExists) {

--- a/src/common/host-utils.js
+++ b/src/common/host-utils.js
@@ -150,9 +150,27 @@ function getHostsStatus (codiusStateJson) {
   })
 }
 
+function getHostList ({ host, manifestHash }) {
+  let hostsArr = []
+  if (!host) {
+    const potentialHost = manifestHash.split('.')
+    potentialHost.shift()
+    if (potentialHost.length <= 0) {
+      throw new Error(`The end of ${manifestHash} is not a valid url. Please use the format <manifesth-hash.hostName> to specify the specific pod to extend or the --host parameter.`)
+    }
+    console.log(potentialHost)
+    hostsArr = [`https://${potentialHost.join('.')}`]
+  } else {
+    hostsArr = host
+  }
+
+  return cleanHostListUrls(hostsArr)
+}
+
 module.exports = {
   cleanHostListUrls,
   getValidHosts,
   checkPricesOnHosts,
-  getHostsStatus
+  getHostsStatus,
+  getHostList
 }

--- a/src/common/pod-control.js
+++ b/src/common/pod-control.js
@@ -6,15 +6,14 @@ const { parse: parseUrl } = require('url')
 const { Transform } = require('stream')
 
 async function attachToLogs (hosts, podId) {
-  logger.debug('attaching to logs. hosts=%s podId=%s', hosts, podId)
+  logger.info('attaching to logs. hosts=%s podId=%s', hosts, podId)
 
   const streams = await Promise.all(hosts.map(async host => {
     const url = parseUrl(host)
 
     const get = (url.protocol === 'https:' ? require('https') : require('http')).get
     const res = await new Promise((resolve, reject) => {
-      const req = get(`${host}/pods/${podId}/logs`, resolve)
-
+      const req = get(`${host}/pods/${podId}/logs?follow=true`, resolve)
       req.on('error', err => reject(err))
     })
 

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -59,8 +59,23 @@ function checkExpirationDates (statusDetails) {
   })
 }
 
+function getManifestHash ({ host, manifestHash }) {
+  if (!host) {
+    return manifestHash.split('.')[0].toString().replace(/^https?:\/\//i, '')
+  }
+  return manifestHash
+}
+
+function checkDebugFlag (manifestJson) {
+  if (manifestJson.debug) {
+    throw new Error('Debug is not valid in the codius.json file, use the --debug option to add this flag during upload.')
+  }
+}
+
 module.exports = {
   checkStatus,
   checkExpirationDates,
-  fetchPromise
+  fetchPromise,
+  getManifestHash,
+  checkDebugFlag
 }

--- a/src/handlers/extend-hash.js
+++ b/src/handlers/extend-hash.js
@@ -5,7 +5,7 @@
  */
 
 const { getCurrencyDetails, unitsPerHost } = require('../common/price.js')
-const { checkPricesOnHosts, cleanHostListUrls } = require('../common/host-utils.js')
+const { checkPricesOnHosts, getHostList } = require('../common/host-utils.js')
 const { extendManifestByHash } = require('../common/manifest-upload.js')
 const axios = require('axios')
 const ora = require('ora')
@@ -14,7 +14,7 @@ const config = require('../config.js')
 const inquirer = require('inquirer')
 const jsome = require('jsome')
 const logger = require('riverpig')('codius-cli:extend-hash')
-const { checkStatus } = require('../common/utils.js')
+const { checkStatus, getManifestHash } = require('../common/utils.js')
 
 async function getExistingManifest (hostList, manifestHash) {
   let responses = []
@@ -37,30 +37,6 @@ async function getExistingManifest (hostList, manifestHash) {
     throw new Error(`One of the hosts: ${hostList} does not have the associated manifest. Please check your host(s) and try again`)
   }
   return responses[0]
-}
-
-function getHostList ({ host, manifestHash }) {
-  let hostsArr = []
-  if (!host) {
-    const potentialHost = manifestHash.split('.')
-    potentialHost.shift()
-    if (potentialHost.length <= 0) {
-      throw new Error(`The end of ${manifestHash} is not a valid url. Please use the format <manifesth-hash.hostName> to specify the specific pod to extend or the --host parameter.`)
-    }
-    console.log(potentialHost)
-    hostsArr = [`https://${potentialHost.join('.')}`]
-  } else {
-    hostsArr = host
-  }
-
-  return cleanHostListUrls(hostsArr)
-}
-
-function getManifestHash ({ host, manifestHash }) {
-  if (!host) {
-    return manifestHash.split('.')[0].toString().replace(/^https?:\/\//i, '')
-  }
-  return manifestHash
 }
 
 function getOptions ({

--- a/src/handlers/tail.js
+++ b/src/handlers/tail.js
@@ -1,0 +1,84 @@
+/**
+ * @fileOverview
+ * @name tail.js<handlers>
+ * @author Travis Crist
+ */
+
+const { getHostList } = require('../common/host-utils.js')
+const ora = require('ora')
+const statusIndicator = ora({ text: '', color: 'blue', spinner: 'point' })
+const { getManifestHash } = require('../common/utils.js')
+const { attachToLogs } = require('../common/pod-control.js')
+const fse = require('fs-extra')
+const nodeDir = require('node-dir')
+const logger = require('riverpig')('codius-cli:tailHandler')
+
+async function getCodiusStateFilePath () {
+  const files = await new Promise((resolve, reject) => {
+    nodeDir.readFiles(process.cwd(), {
+      match: /\.codiusstate\.json$/, recursive: false
+    }, (err, content, next) => {
+      if (err) throw err
+      next()
+    }, (err, files) => {
+      if (err) reject(err)
+      resolve(files)
+    })
+  })
+
+  let codiusStateFilePath
+  if (files.length === 1) {
+    codiusStateFilePath = files[0]
+    logger.debug(`Found ${codiusStateFilePath} file`)
+  } else if (files.length > 1) {
+    throw new Error(`Found multiple *.codiusstate.json files:\n${JSON.stringify(files)}\nonly one *.codiusstate.json file is supported.`)
+  } else {
+    throw new Error(`Unable to find any *codiusstate.json files, please check that one exists in your current working directory ${process.cwd()}. Run 'codius upload <commands>' to create a *.codiusstate.json file.`)
+  }
+
+  return codiusStateFilePath
+}
+
+async function tail (options) {
+  try {
+    statusIndicator.start('Checking Options')
+    let hostList
+    let manifestHash
+    if (options.manifestHash) {
+      hostList = getHostList(options)
+      manifestHash = getManifestHash(options)
+      logger.debug(`host list: ${hostList}`)
+      logger.debug(`manifest hash: ${manifestHash}`)
+    } else {
+      let codiusStateFilePath
+      if (options.codiusStateFile !== 'default.codiusstate.json') {
+        statusIndicator.start(`Checking ${options.codiusStateFile} exists`)
+        const codiusStateExists = await fse.pathExists(options.codiusStateFile)
+        if (!codiusStateExists) {
+          throw new Error(`Codius State File at ${options.codiusStateFile} does not exist, please check the provided file location`)
+        }
+        codiusStateFilePath = options.codiusStateFile
+      } else {
+        statusIndicator.start(`Checking for *.codiusstate.json file in current dir ${process.cwd()}`)
+        codiusStateFilePath = await getCodiusStateFilePath()
+      }
+      const codiusStateJson = await fse.readJson(codiusStateFilePath)
+      hostList = codiusStateJson.hostList
+      manifestHash = codiusStateJson.manifestHash
+    }
+    statusIndicator.succeed('Options Validated Successfully')
+    const logStream = await attachToLogs(hostList, manifestHash)
+    logStream.on('data', data => {
+      logger.info(data.toString())
+    })
+  } catch (err) {
+    statusIndicator.fail()
+    logger.error(err.message)
+    logger.debug(err)
+    process.exit(1)
+  }
+}
+
+module.exports = {
+  tail
+}


### PR DESCRIPTION
#50 Add support for tailing logs after upload. 

Ready for review. 

Uses --debug flag to add debug var with true to manifest, adds --tail flag to tail logs on upload. Adds tail command to tail logs using the tail command for any pod uploaded with the --debug flag. 