### PR TITLE
should give different help msg for different OS

### DIFF
--- a/src/common/price.js
+++ b/src/common/price.js
@@ -45,10 +45,9 @@ async function unitsPerHost ({
     const priceResp = await Promise.race([timeoutPromise, priceFetchPromise])
     clearTimeout(timer)
     if (!priceResp) {
-      if(os.platform() === 'win32'){
+      if (os.platform() === 'win32') {
         throw new Error('unable to make to make ILP Connection, run Codius CLI in debug via command:\n\'set DEBUG=* & codius <commands>\'\nto verify you are connected.')
-      }
-      else{
+      } else {
         throw new Error('unable to make to make ILP Connection, run Codius CLI in debug via command:\n\'DEBUG=* codius <commands>\'\nto verify you are connected.')
       }
     }

--- a/src/common/price.js
+++ b/src/common/price.js
@@ -3,7 +3,7 @@
  * @name price.js
  * @author Travis Crist
  */
-
+const os = require('os')
 const config = require('../config.js')
 const Price = require('ilp-price')
 const plugin = require('ilp-plugin')()
@@ -45,7 +45,12 @@ async function unitsPerHost ({
     const priceResp = await Promise.race([timeoutPromise, priceFetchPromise])
     clearTimeout(timer)
     if (!priceResp) {
-      throw new Error('unable to make ILP Connection, run Codius CLI in debug via command:\n\'DEBUG=* codius <commands>\'\nto verify you are connected.')
+      if(os.platform() === 'win32'){
+        throw new Error('unable to make to make ILP Connection, run Codius CLI in debug via command:\n\'set DEBUG=* & codius <commands>\'\nto verify you are connected.')
+      }
+      else{
+        throw new Error('unable to make to make ILP Connection, run Codius CLI in debug via command:\n\'DEBUG=* codius <commands>\'\nto verify you are connected.')
+      }
     }
     const quotedPrice = new BigNumber(priceResp)
     // Increase the price by 8/100ths of a percent since the server rounds up so we are not  off by a few drops


### PR DESCRIPTION
For *nix OS, the debug command is "DEBUG=* codius <commands>"
For windows, the debug command is "set DEBUG=*  & codius <commands>"


## Run Test on windows:

- codius upload --host  https://codius.tinypolarbear.com --duration 200

‼ Hosts will NOT be added to the HOSTS env in the generated manifest.
√ Validating File Locations
 Generating Codius Manifest
×Calculating Max Monthly Rate
2018-08-23T07:13:35.480Z codius-cli:uploadhandler error ilp-price lookup failed: unable to make to make ILP Connection, run Codius CLI in debug via command:
'set DEBUG=* & codius  < commands > '
to verify you are connected.


- set DEBUG=* & codius upload --host  https://codius.tinypolarbear.com --duration 200

2018-08-23T07:13:53.393Z ilp-plugin debug creating plugin with module ilp-plugin-btp
2018-08-23T07:13:53.395Z ilp-plugin debug creating plugin with credentials { server: 'btp+ws://:115522e08ad4437b75276575fbac8375@localhost:7768' }
2018-08-23T07:13:53.981Z codius-cli:upload debug Upload manifest args: {"_":["upload"],"version":false,"help":false,"add-host-env":false,"a":false,"addHostEnv":false,"overwrite-codius-state":false,"o":false,"overwriteCodiusState":false,"assume-yes":false,"y":false,"assumeYes":false,"debug":false,"tail":false,"host":"https://codius.tinypolarbear.com","duration":200,"d":200,"codius-file":"codius.json","codiusFile":"codius.json","codius-vars-file":"codiusvars.json","codiusVarsFile":"codiusvars.json","codius-hosts-file":"codiushosts.json","codiusHostsFile":"codiushosts.json","codius-state-file":"default.codiusstate.json","codiusStateFile":"default.codiusstate.json","$0":"AppData\\Roaming\\npm\\node_modules\\codius\\bin\\codius.js"}
‼ Hosts will NOT be added to the HOSTS env in the generated manifest.
2018-08-23T07:13:53.987Z codius-cli:codius-state debug overwrite codius state: false
√ Validating File Locations
-Generating Codius Manifest2018-08-23T07:13:53.996Z codius-manifest:generate-manifest debug validating Codius file at codius.json...
2018-08-23T07:13:54.006Z codius-manifest:generate-manifest debug validating Codius vars file at codiusvars.json...
2018-08-23T07:13:54.012Z codius-manifest:generate-manifest debug generating compelete manifest...
2018-08-23T07:13:54.015Z codius-manifest:generate-manifest debug Generating public encoding for EXAMPLE_PRIVATE_ENV
2018-08-23T07:13:54.018Z codius-manifest:generate-manifest debug New encoding for EXAMPLE_PRIVATE_ENV: {
  "encoding": "private:sha256",
  "value": "2523afdc4bcbe3ce8210431ae21b451e4f3fb024629e93f17f58c8ac12962c5a"
}
2018-08-23T07:13:54.020Z codius-manifest:generate-manifest debug validating generated manifest...
2018-08-23T07:13:54.021Z codius-manifest:validate-generated-manifest debug validating generated manifest...
2018-08-23T07:13:54.023Z codius-manifest:validate-schema debug validating manifest schema...
2018-08-23T07:13:54.028Z codius-manifest:validate-schema debug schema errors: []
2018-08-23T07:13:54.030Z codius-manifest:validate-containers debug validating containers...
2018-08-23T07:13:54.031Z codius-manifest:validate-containers debug environment: {
  "EXAMPLE_PUBLIC_ENV": "$EXAMPLE_PUBLIC_ENV",
  "EXAMPLE_PRIVATE_ENV": "$EXAMPLE_PRIVATE_ENV"
}
2018-08-23T07:13:54.035Z codius-manifest:validate-containers debug container validation errors: []
2018-08-23T07:13:54.036Z codius-manifest:validate-publicvars debug validating public variables...
2018-08-23T07:13:54.037Z codius-manifest:validate-publicvars debug public variable errors: []
2018-08-23T07:13:54.038Z codius-manifest:validate-privatevars debug validating private variables...
2018-08-23T07:13:54.040Z codius-manifest:validate-privatevars debug private variable errors: []
2018-08-23T07:13:54.041Z codius-manifest:validate-generated-manifest debug manifest errors: []
2018-08-23T07:13:54.042Z codius-manifest:generate-manifest debug validating image digest...
2018-08-23T07:13:54.044Z codius-manifest:resolve-image debug validating image. image=nginx@sha256:3e2ffcf0edca2a4e9b24ca442d227baea7b7f0e33ad654ef1eb806fbd9bedcf0
